### PR TITLE
fixed PropTypes deprecation 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-writebox",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "ReactNative autogrow text area",
   "main": "index.js",
   "directories": {

--- a/src/WriteboxContainer.js
+++ b/src/WriteboxContainer.js
@@ -1,5 +1,6 @@
 /* @flow */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
   View,
   Text,

--- a/src/WriteboxInput.js
+++ b/src/WriteboxInput.js
@@ -1,5 +1,6 @@
 /* @flow */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
   View,
   Text,

--- a/src/WriteboxLayout.js
+++ b/src/WriteboxLayout.js
@@ -1,5 +1,6 @@
 /* @flow */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { 
   View, 
   Text, 


### PR DESCRIPTION
Hey there, 

PropTypes has been moved out of react, into it's own repo, just removed the deprecation.